### PR TITLE
Fixing cookbook reference and extra line breaks

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -12,5 +12,5 @@ cookbook 'rsyslog', '>= 1.11.0', git: 'git://github.com/opscode-cookbooks/rsyslo
 cookbook 'windows', '>= 1.30.0', git: 'git://github.com/opscode-cookbooks/windows.git', tag: 'v1.30.2'
 cookbook 'yum', git: 'git://github.com/opscode-cookbooks/yum.git', tag: 'v3.1.0'
 cookbook 'yum-epel', '>= 0.3.4', git: 'git://github.com/opscode-cookbooks/yum-epel.git', tag: 'v0.3.4'
-cookbook 'elasticsearch', git: 'git://github.com/elasticsearch/cookbook-elasticsearch.git', tag: '0.3.7'
+cookbook 'elasticsearch', git: 'git://github.com/ryanvanderpol/cookbook-elasticsearch.git'
 cookbook 'mongodb', git: 'git://github.com/edelight/chef-mongodb'

--- a/opsworks-elasticsearch-11-10.template
+++ b/opsworks-elasticsearch-11-10.template
@@ -23,7 +23,7 @@
         "CookbookRepo": {
             "Description": "GitURL",
             "Type": "String",
-            "Default": "https://github.com/amazonwebservices/opsworks-elasticsearch-cookbook"
+            "Default": "https://github.com/ryanvanderpol/opsworks-elasticsearch-cookbook"
         }
     },
     "Conditions": {
@@ -302,7 +302,7 @@
                     {
                         "MountPoint": "/mnt/elasticsearch-data",
                         "NumberOfDisks": 1,
-                        "Size": 100
+                        "Size": 10
                     }
                 ],
                 "CustomSecurityGroupIds": [


### PR DESCRIPTION
CloudFormation would not read the template prior to this change due to an invalid reference and some extra line breaks.
